### PR TITLE
Exit 0 on --complete, added possible arguments

### DIFF
--- a/bin/pyenv-autoenv
+++ b/bin/pyenv-autoenv
@@ -19,9 +19,12 @@ set -e
 # Provide pyenv completions
 if [ "$1" = "--complete" ]; then
   echo --clear
+  echo --clear-if-lower
   echo --name
   echo --python
   echo --no-local
+  echo --quiet
+  exit 0;
 fi
 
 usage() {


### PR DESCRIPTION
Just a quick fix to get rid of messages like the following when using TAB for completion
```
> pyenv autoenv usage: autoenv.py [-h] [--name NAME] [--python PYTHON] [--version] [--clear]
                  [--clear-if-lower] [--no-local] [-q]
autoenv.py: error: unrecognized arguments: --complete
                --usage: autoenv.py [-h] [--name NAME] [--python PYTHON] [--version] [--clear]
                  [--clear-if-lower] [--no-local] [-q]
autoenv.py: error: unrecognized arguments: --complete
  pyenv autoenv --
git:(main) 
```