### PR TITLE
Natural Sort Python Version + Completion-Fix

### DIFF
--- a/bin/pyenv-autoenv
+++ b/bin/pyenv-autoenv
@@ -19,9 +19,12 @@ set -e
 # Provide pyenv completions
 if [ "$1" = "--complete" ]; then
   echo --clear
+  echo --clear-if-lower
   echo --name
   echo --python
   echo --no-local
+  echo --quiet
+  exit 0;
 fi
 
 usage() {

--- a/bin/pyenv-autoenv
+++ b/bin/pyenv-autoenv
@@ -2,7 +2,7 @@
 #
 # Summary: Create a virtualenv automatically.
 #
-# Usage: pyenv autoenv [--clear] [--local] [--name NAME] [--python PYTHON]
+# Usage: pyenv autoenv [--clear] [--no-local] [--name NAME] [--python PYTHON]
 #        pyenv autoenv --version
 #        pyenv autoenv --help
 #

--- a/libexec/autoenv.py
+++ b/libexec/autoenv.py
@@ -110,7 +110,7 @@ class VersionDetector:
         return None
 
     def get_latest_version(self) -> "str":
-        for version in sorted(self.definitions, reverse=True):
+        for version in reversed(self.definitions):
             if re.match(r"\d+\.\d+\.\d+$", version):  # type: ignore
                 return version  # type: ignore
         raise SystemExit("Couldn't find any usable Python versions")
@@ -216,7 +216,9 @@ def get_versions(name: str, desired_python: "str | None" = None) -> Versions:
 
 
 def get_installed_versions() -> "list[str]":
-    return _get_command_output(["pyenv", "versions", "--bare"]).splitlines()
+    natsort = lambda s: [int(t) if t.isdigit() else t.lower() for t in re.split('(\d+)', s)]
+    sorted_list = sorted(_get_command_output(["pyenv", "versions", "--bare", "--skip-aliases"]).splitlines(), key=natsort)
+    return sorted_list
 
 
 def get_definitions() -> "list[str]":


### PR DESCRIPTION
This should correctly install the latest Version with digits like 3.9.9 and 3.10.2 in mind. It always installed the 3.9.9 prior to this patch.
And the `--complete` _call_ from pushing Tab doesn't execute autoenv.py anymore. Maybe it should be handled different but at least i don't get any errors anymore.

cheers,
~crpb
